### PR TITLE
Return success of handle_fallback

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -72,10 +72,10 @@ class LearningSkill(FallbackSkill):
         utterance = message.data['utterance']
         if os.path.exists(self.public_path):
             path = self.public_path
-            self.load_fallback(utterance, path)
+            return self.load_fallback(utterance, path)
         if os.path.exists(self.local_path):
             path = self.local_path
-            self.load_fallback(utterance, path)
+            return self.load_fallback(utterance, path)
 
     def load_fallback(self, utterance, path):
             for f in os.listdir(path):
@@ -96,11 +96,9 @@ class LearningSkill(FallbackSkill):
                             lines = open(e).read().splitlines()
                             i =random.choice(lines)
                             self.speak_dialog(i)
-                            return
-                        return
-                    return
+                            return True
                 self.log.debug('fallback learning: ignoring')
-            return
+            return False
 
     @intent_handler(IntentBuilder("HandleInteraction").require("Query").optionally("Something").
                     optionally("Private").require("Learning"))


### PR DESCRIPTION
Hi Andreas, 
I gave the new version another test and found that after it responded to the learned question, then other Fallback skills would also respond. This happens if we don't return True from `handle_fallback()`. There's a [small section about this here](https://mycroft.ai/documentation/skills/fallback-skill/#creating-a-fallback-skill).

Here is one possible solution that returns a boolean from `load_fallback()` and this result is then returned from `handle_fallback()`.