### PR TITLE
fix settings.get() and minor edits

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -32,7 +32,7 @@ class LearningSkill(FallbackSkill):
         LOG.debug('local path enabled: %s' % self.local_path)
 
         if self.enable_fallback is True:
-            self.register_fallback(self.handle_fallback, 5)
+            self.register_fallback(self.handle_fallback, 6)
         LOG.debug('Learning-skil-fallback enabled: %s' % self.enable_fallback)
 
     def init_category(self, cat):
@@ -138,10 +138,10 @@ class LearningSkill(FallbackSkill):
             os.makedirs(answer_path)
         if not os.path.isdir(question_path):
             os.makedirs(question_path)
-        confirm_save = self.get_response(
-            dialog="save.learn",
+        confirm_save = self.ask_yesno(
+            "save.learn",
             data={"question": question, "answer": answer})
-        if confirm_save.lower() != "yes":
+        if confirm_save != "yes":
             self.log.debug('new knowledge rejected')
             return  # user cancelled
         save_dialog = open(answer_path+"/"+keywords.replace(" ", ".")+".dialog", "a")

--- a/__init__.py
+++ b/__init__.py
@@ -21,14 +21,17 @@ class LearningSkill(FallbackSkill):
         self.Category = ""
 
     def initialize(self):
-        self.enable_fallback = self.settings.get("enable_fallback_ex", "True")
-        self.public_path = self.settings.get('public_path_ex', self.file_system.path+"/public")
-        self.local_path = self.settings.get('local_path_ex', self.file_system.path+"/private")
-        self.allow_category = self.settings.get('allow_category_ex', "humor,love,science")
+        self.enable_fallback = self.settings.get('enable_fallback_ex') \
+            if self.settings.get('enable_fallback_ex') is not None else True
+        self.public_path = self.settings.get('public_path_ex') \
+            if self.settings.get('public_path_ex') else self.file_system.path+"/public"
+        self.local_path = self.settings.get('local_path_ex') \
+            if self.settings.get('local_path_ex') else self.file_system.path+"/private"
+        self.allow_category = self.settings.get('allow_category_ex') \
+            if self.settings.get('allow_category_ex') else "humor,love,science"
         LOG.debug('local path enabled: %s' % self.local_path)
 
-
-        if self.enable_fallback is "True":
+        if self.enable_fallback is True:
             self.register_fallback(self.handle_fallback, 5)
         LOG.debug('Learning-skil-fallback enabled: %s' % self.enable_fallback)
 
@@ -135,17 +138,19 @@ class LearningSkill(FallbackSkill):
             os.makedirs(answer_path)
         if not os.path.isdir(question_path):
             os.makedirs(question_path)
-        self.speak_dialog("save.learn",
-                          data={"question": question,
-                                "answer": answer},
-                                expect_response = True)
-
+        confirm_save = self.get_response(
+            dialog="save.learn",
+            data={"question": question, "answer": answer})
+        if confirm_save.lower() != "yes":
+            self.log.debug('new knowledge rejected')
+            return  # user cancelled
         save_dialog = open(answer_path+"/"+keywords.replace(" ", ".")+".dialog", "a")
         save_dialog.write(answer+"\n")
         save_dialog.close()
         save_intent = open(question_path+"/"+keywords.replace(" ", ".")+".intent", "a")
         save_intent.write(question+"\n")
         save_intent.close()
+        self.log.debug('new knowledge saved')
 
     def shutdown(self):
         self.remove_fallback(self.handle_fallback)


### PR DESCRIPTION
Hi Andreas,

I'm going to have to further investigate the `self.settings.get()` method but have proposed an alternative in the meantime.

I've suggesting setting `enable_fallback` to be a boolean rather than "True" string.

The Fallback priority I dropped by one to be inside the user allocated range. This is very new and is [outlined in the Fallback class](https://github.com/MycroftAI/mycroft-core/blob/7f59aa60f4f26f3b30e41b0373b66b68ddecde17/mycroft/skills/core.py#L1655)

With the final save question, it wasn't processing the answer at all so I also modified this to an ask_yesno() which I believe should work across languages.